### PR TITLE
Add Twitter card meta tags

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -12,6 +12,11 @@
   <meta property="og:title"              content="Orchid is the natural internet." />
   <meta property="og:description"        content="Orchid is a suite of open source tools and cryptographic protocols developed and run by people who want the internet to extend our natural human freedom, not curtail it. Our initial focus is an open marketplace for bandwidth built on Ethereum, and a VPN client for all major operating systems." />
   <meta property="og:image"              content="https://orchid.com/assets/img/index/splash/1x.png" />
+  <meta name="twitter:card"              content="summary" />
+  <meta name="twitter:site"              content="@OrchidProtocol" />
+  <meta name="twitter:title"             content="Orchid is the natural internet." />
+  <meta name="twitter:description"       content="Orchid is a suite of open source tools and cryptographic protocols developed and run by people who want the internet to extend our natural human freedom, not curtail it. Our initial focus is an open marketplace for bandwidth built on Ethereum, and a VPN client for all major operating systems." />
+  <meta name="twitter:image"             content="https://orchid.com/assets/img/index/splash/1x.png" />
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
When users link to our site on Twitter, a preview card is not being
displayed. This change follows
https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/abouts-cards
to add additional <meta> tags to make a summary card appear.