### PR TITLE
Update deploy.sh to use new staging git repo

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -45,7 +45,7 @@ if [ "$1" == "--help" ]; then
 elif [ "$1" == "opuslogica" ]; then
     scp -rp ${built_files}/* .htaccess opuslogica.com:/www/sites/orchid.opuslogica.com/
 elif [ "$1" == "staging" ]; then
-    copy-push 'ssh://git-codecommit.us-west-2.amazonaws.com/v1/repos/new.orchid.com'
+    copy-push 'ssh://git-codecommit.us-west-2.amazonaws.com/v1/repos/orchid.dev'
 elif [ "$1" == "production" ]; then
     copy-push 'ssh://git-codecommit.us-west-2.amazonaws.com/v1/repos/orchid.com'
 fi


### PR DESCRIPTION
Our staging site has moved from new.orchid.com to orchid.dev. As part of this change, the name of the git repository used to deploy to S3 has also been updated. This change adjusts the deploy.sh script to deploy to the correct repository.