### PR TITLE
Add a /whitepaper.pdf symlink

### DIFF
--- a/static-render.sh
+++ b/static-render.sh
@@ -102,6 +102,7 @@ if [ ! -d "$OUT_DIR"/assets/img ]; then mkdir -p "$OUT_DIR"/assets/img; fi
 cp -r src/assets/img/* "$OUT_DIR"/assets/img
 mkdir -p "$OUT_DIR"/assets/whitepaper 2>/dev/null
 cp src/assets/whitepaper/whitepaper.pdf "$OUT_DIR"/assets/whitepaper/
+ln -s ./assets/whitepaper/whitepaper.pdf "$OUT_DIR"/whitepaper.pdf
 cat >> "$OUT_DIR"/version.html <<EOF
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
Our whitepaper used to be available at /whitepaper.pdf. It is now at
/whitepaper/whitepaper.pdf. From looking at some logs, it appears that
some people are still trying to access the old URL. This change adds a
symlink pointing at the whitepaper to restore the old path. We can later
transition this to an HTTP redirect and eventually remove it completely.